### PR TITLE
Fix skip tests number

### DIFF
--- a/t/01-simple.t
+++ b/t/01-simple.t
@@ -15,7 +15,7 @@ eval { $conn = MongoDB::MongoClient->new; };
 SKIP: {
 	if ($@) {
 		diag("MongoDB needs to be running for this test.");
-		skip("MongoDB needs to be running for this test.", 3);
+		skip("MongoDB needs to be running for this test.", 2);
 	}
 
 	my @messages = (


### PR DESCRIPTION
There are only 2 tests in `t/01-simple.t`, but three tests are skipped when MongoDB server does not run. I got following error message when testing.

```
% prove -bv t/01-simple.t 
t/01-simple.t .. 
1..2
# MongoDB needs to be running for this test.
ok 1 # skip MongoDB needs to be running for this test.
ok 2 # skip MongoDB needs to be running for this test.
ok 3 # skip MongoDB needs to be running for this test.
not ok 4 - planned to run 2 but done_testing() expects 3

#   Failed test 'planned to run 2 but done_testing() expects 3'
#   at /home/syohei/.plenv/versions/5.22.0/lib/perl5/5.22.0/Test/More.pm line 220.
# Looks like you planned 2 tests but ran 4.
```
